### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ python:
   - "3.8"
   - "nightly"
 
+arch:
+  - amd64
+  - ppc64le
+  
 install:
   - pip install .
 


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues 
or failures early would help to ensure that we are always up to date.